### PR TITLE
Implement GPT-driven CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Interact with the database using natural language via the GPT API."""
+
+import json
+import os
+import sys
+
+import openai
+
+from tool import agregar, obtener, eliminar
+
+MODEL = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
+API_KEY = os.getenv("OPENAI_API_KEY")
+
+
+def main() -> None:
+    if API_KEY is None:
+        raise RuntimeError("OPENAI_API_KEY environment variable not set")
+    openai.api_key = API_KEY
+
+    if len(sys.argv) < 2:
+        print("Uso: cli.py <consulta>")
+        return
+    query = " ".join(sys.argv[1:])
+
+    system_prompt = (
+        "Convierte la solicitud del usuario en un objeto JSON que indique la accion\n"
+        '{"action": "agregar", "texto": "..."} | '
+        '{"action": "obtener", "id": 1} | '
+        '{"action": "eliminar", "id": 1}.\n'
+        "Responde solo con el JSON."
+    )
+
+    resp = openai.ChatCompletion.create(
+        model=MODEL,
+        messages=[{"role": "system", "content": system_prompt}, {"role": "user", "content": query}],
+    )
+    content = resp.choices[0].message.content
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError:
+        print("Respuesta inesperada:", content)
+        return
+
+    action = data.get("action")
+    if action == "agregar":
+        result = agregar(data.get("texto", ""))
+    elif action == "obtener":
+        result = obtener(int(data.get("id")))
+    elif action == "eliminar":
+        result = eliminar(int(data.get("id")))
+    else:
+        result = f"Accion no soportada: {action}"
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/db.py
+++ b/db.py
@@ -1,7 +1,23 @@
 # db.py
+"""Database setup for the MCP server."""
+
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
 from models import Base
 
-engine = create_engine("postgresql+psycopg2://usuario:password@localhost/mi_db")
-SessionLocal = sessionmaker(bind=engine)
+
+# Allow the database URL to be configured via an environment variable.  If none
+# is provided, fall back to a local SQLite database for easier testing.
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///db.sqlite3")
+
+# Create the SQLAlchemy engine and session factory.  autocommit/autoflush are
+# disabled to mirror typical FastAPI style usage.
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def init_db() -> None:
+    """Create tables if they do not already exist."""
+    Base.metadata.create_all(engine)

--- a/server.py
+++ b/server.py
@@ -1,4 +1,26 @@
-# server.py
+from __future__ import annotations
+
+"""FastMCP server exposing simple Postgres operations."""
+
+from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator
+
 from mcp.server.fastmcp import FastMCP
-from db import SessionLocal
-from models import Registro, Base
+
+from db import init_db
+
+
+@asynccontextmanager
+async def lifespan(server: FastMCP) -> AsyncIterator[None]:
+    """Initialize the database on startup."""
+    init_db()
+    yield
+
+
+mcp = FastMCP("Postgres GPT Server", lifespan=lifespan)
+
+# Register tool implementations
+import tool  # noqa: E402
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tool.py
+++ b/tool.py
@@ -1,24 +1,31 @@
-# Crear
+# Tools for interacting with the ``registros`` table.
+
+from server import mcp
+from db import SessionLocal
+from models import Registro
+
+
 @mcp.tool(title="Agregar registro")
 def agregar(texto: str) -> str:
+    """Insert a new row into the database."""
     with SessionLocal() as session:
         reg = Registro(texto=texto)
         session.add(reg)
         session.commit()
         return f"Registro {reg.id} agregado"
 
-# Consultar
 @mcp.tool(title="Obtener registro")
 def obtener(id: int) -> str:
+    """Return the text for a stored record by ID."""
     with SessionLocal() as session:
         reg = session.get(Registro, id)
         if reg:
             return reg.texto
         return "No encontrado"
 
-# Eliminar
 @mcp.tool(title="Eliminar registro")
 def eliminar(id: int) -> str:
+    """Delete a record by its ID."""
     with SessionLocal() as session:
         reg = session.get(Registro, id)
         if reg:


### PR DESCRIPTION
## Summary
- create a small CLI that sends natural language queries to the GPT API
- route GPT responses to the existing MCP tools for database operations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685ada2339dc832c81e99c51e9cfe51d

## Resumen por Sourcery

Implementa una CLI impulsada por GPT para operaciones de bases de datos en lenguaje natural y la integra con el servidor MCP, al tiempo que mejora la configuración e inicialización de la base de datos.

Nuevas Funcionalidades:
- Agrega la CLI `cli.py` que convierte la entrada del usuario en acciones JSON a través de la API de GPT y ejecuta las operaciones de base de datos correspondientes.
- Registra `agregar`, `obtener` y `eliminar` como herramientas MCP para operaciones CRUD en la tabla `registros`.

Mejoras:
- Configura la conexión de la base de datos a través de una variable de entorno `DATABASE_URL` con una alternativa SQLite para facilitar las pruebas.
- Inicializa automáticamente el esquema de la base de datos al iniciar el servidor utilizando un administrador de contexto de vida útil FastMCP.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement a GPT-driven CLI for natural language database operations and integrate it with the MCP server while enhancing database configuration and initialization.

New Features:
- Add `cli.py` CLI that converts user input into JSON actions via the GPT API and executes corresponding database operations.
- Register `agregar`, `obtener`, and `eliminar` as MCP tools for CRUD operations on the `registros` table.

Enhancements:
- Configure the database connection via a `DATABASE_URL` environment variable with a SQLite fallback for easier testing.
- Automatically initialize the database schema at server startup using a FastMCP lifespan context manager.

</details>